### PR TITLE
Use a newer Pickle protocol.

### DIFF
--- a/blaecksprutte.py
+++ b/blaecksprutte.py
@@ -116,7 +116,8 @@ def main():
     if args.command == 'train':
         v, b, c = train_from_bottom(log)
         with open(filename, 'wb') as f:
-            cPickle.dump([v, b, c], f)
+            cPickle.dump([v, b, c], f,
+                         cPickle.HIGHEST_PROTOCOL)
 
     if args.command == 'tag':
         tag_new_mails(filename, log)


### PR DESCRIPTION
By default the Pickle modules use the oldest serialization protocol
for backwards compatibility with Python < 2.3.  Using a newer protocol
improves file size and deserialization time dramatically:

    % /usr/bin/time -p python -c 'import cPickle as pickle;
        pickle.load(open("blaecksprutte.db"))'
    real 4.98
    user 4.76
    sys 0.22
    % /usr/bin/time -p python -c 'import cPickle as pickle;
        pickle.load(open("blaecksprutte.db.picklev2"))'
    real 1.27
    user 1.12
    sys 0.14
    % du --bytes blaecksprutte.db blaecksprutte.db.picklev2
    214862607       blaecksprutte.db
    65781466        blaecksprutte.db.picklev2